### PR TITLE
Support Canadian addresses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,6 @@ Metrics/LineLength:
 
 Metrics/MethodLength:
   Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.com/juliannaroen/address_titlecase.svg?token=GqtPi1VKmx9gqq9JuxSW&branch=master)](https://travis-ci.com/juliannaroen/address_titlecase)
 [![Gem Version](https://badge.fury.io/rb/address_titlecase.svg)](https://badge.fury.io/rb/address_titlecase)
 
-Titleize US addresses so that states, directions, and other abbreviations that would normally be titlecased by [`String#titleize`](https://apidock.com/rails/String/titleize) remain uppercase.
+Titleize US and Canadian addresses so that states, directions, and other abbreviations that would normally be titlecased by [`String#titleize`](https://apidock.com/rails/String/titleize) remain uppercase.
 
 ```ruby
 > "123 SESAME ST SE, SALEM, OR 97301".address_titlecase

--- a/address_titlecase.gemspec
+++ b/address_titlecase.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'pry-byebug'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'bundler', '~> 2.1'
+  spec.add_development_dependency 'pry-byebug', '~> 3.7'
+  spec.add_development_dependency 'rake', '~> 10.5'
+  spec.add_development_dependency 'rspec', '~> 3.8'
+  spec.add_development_dependency 'rubocop', '~> 0.72'
 end

--- a/lib/address_titlecase/titleizer.rb
+++ b/lib/address_titlecase/titleizer.rb
@@ -12,15 +12,20 @@ module AddressTitlecase
   class Titleizer
     class << self
       US_STATES = %w[AL AK AZ AR CA CO CT DE FL GA HI ID IL IN IA KS KY LA ME MD MA MI MN MS MO MT NE NV NH NJ NM NY NC ND OH OK OR PA RI SC SD TN TX UT VT VA WA WV WI WY].freeze
-      TERRITORIES = %w[AS DC FM GU MH MP PW PR VI].freeze
+      US_TERRITORIES = %w[AS DC FM GU MH MP PW PR VI].freeze
+
+      CA_PROVINCES = %w[AB BC MB NB NL NS ON PE QC SK].freeze
+      CA_TERRITORIES = %w[NT NU YT].freeze
+
       MILITARY = %w[APO FPO MPO AE AA AP].freeze
+
       DIRECTIONS = %w[NE NW SE SW].freeze
       COUNTRIES = %w[USA].freeze
       MISC = %w[PO RR].freeze
 
-      REMAIN_UPCASE = US_STATES | TERRITORIES | MILITARY | DIRECTIONS | COUNTRIES | MISC
+      REMAIN_UPCASE = US_STATES | US_TERRITORIES | CA_PROVINCES | CA_TERRITORIES | MILITARY | DIRECTIONS | COUNTRIES | MISC
 
-      def titleize(address, opts)
+      def titleize(address, opts = {})
         overrides = opts['overrides'] || opts[:overrides] || {}
         address.gsub(/\w+['’]?\w*/) do |word|
           overriden_word = overrides[word]

--- a/lib/address_titlecase/titleizer.rb
+++ b/lib/address_titlecase/titleizer.rb
@@ -31,7 +31,7 @@ module AddressTitlecase
           overriden_word = overrides[word]
           if overriden_word
             overriden_word
-          elsif REMAIN_UPCASE.include?(word.upcase) || zip_code_with_letters?(word)
+          elsif REMAIN_UPCASE.include?(word.upcase) || contains_digits?(word)
             word.upcase
           else
             word.capitalize
@@ -41,7 +41,7 @@ module AddressTitlecase
 
       private
 
-      def zip_code_with_letters?(word)
+      def contains_digits?(word)
         !word.count('0-9').zero?
       end
     end

--- a/lib/address_titlecase/titleizer.rb
+++ b/lib/address_titlecase/titleizer.rb
@@ -31,12 +31,18 @@ module AddressTitlecase
           overriden_word = overrides[word]
           if overriden_word
             overriden_word
-          elsif REMAIN_UPCASE.include?(word.upcase)
+          elsif REMAIN_UPCASE.include?(word.upcase) || zip_code_with_letters?(word)
             word.upcase
           else
             word.capitalize
           end
         end
+      end
+
+      private
+
+      def zip_code_with_letters?(word)
+        !word.count('0-9').zero?
       end
     end
   end

--- a/lib/address_titlecase/version.rb
+++ b/lib/address_titlecase/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AddressTitlecase
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/spec/address_titlecase/titleizer_spec.rb
+++ b/spec/address_titlecase/titleizer_spec.rb
@@ -4,37 +4,35 @@ require 'spec_helper'
 
 describe AddressTitlecase::Titleizer do
   describe '.titleize' do
-    subject(:titleize) { described_class.titleize(input_address, overrides: overrides) }
+    subject(:titleize) { described_class.titleize(input_address) }
 
-    context 'without overrides' do
-      let(:titleized_address) { "123 Sesame St SE\nSalem, OR 97301" }
-      let(:overrides) { {} }
+    context 'with a downcased address' do
+      let(:input_address) { "123 sesame st se\nsalem, or 97301" }
 
-      context 'with a downcased address' do
-        let(:input_address) { "123 sesame st se\nsalem, or 97301" }
+      it { is_expected.to eq("123 Sesame St SE\nSalem, OR 97301") }
+    end
 
-        it { is_expected.to eq(titleized_address) }
-      end
+    context 'with an upcased address' do
+      let(:input_address) { "123 SESAME ST SE\nSALEM, OR 97301" }
 
-      context 'with a upcased address' do
-        let(:input_address) { "123 SESAME ST SE\nSALEM, OR 97301" }
+      it { is_expected.to eq("123 Sesame St SE\nSalem, OR 97301") }
+    end
 
-        it { is_expected.to eq(titleized_address) }
-      end
+    context 'with a typical titlecased address' do
+      let(:input_address) { "123 Sesame St Se\nSalem, Or 97301" }
 
-      context 'with an inproper titlecased address' do
-        let(:input_address) { "123 Sesame St Se\nSalem, Or 97301" }
-
-        it { is_expected.to eq(titleized_address) }
-      end
+      it { is_expected.to eq("123 Sesame St SE\nSalem, OR 97301") }
     end
 
     context 'with overrides' do
-      let(:overrides) { { 'Se' => 'Se', 'St' => 'ST' } }
-      let(:input_address) { "123 Sesame St Se\nSalem, Or 97301" }
-      let(:titleized_address) { "123 Sesame ST Se\nSalem, OR 97301" }
+      subject(:titleize) do
+        described_class.titleize(
+          "123 Sesame St Se\nSalem, Or 97301",
+          overrides: { 'Se' => 'Se', 'St' => 'ST' }
+        )
+      end
 
-      it { is_expected.to eq(titleized_address) }
+      it { is_expected.to eq("123 Sesame ST Se\nSalem, OR 97301") }
     end
   end
 end

--- a/spec/address_titlecase/titleizer_spec.rb
+++ b/spec/address_titlecase/titleizer_spec.rb
@@ -24,6 +24,12 @@ describe AddressTitlecase::Titleizer do
       it { is_expected.to eq("123 Sesame St SE\nSalem, OR 97301") }
     end
 
+    context 'with a Canadian address' do
+      let(:input_address) { "10-123 1/2 MAIN ST SE\nMONTREAL QC H3Z 2Y7" }
+
+      it { is_expected.to eq("10-123 1/2 Main St SE\nMontreal QC H3Z 2Y7") }
+    end
+
     context 'with overrides' do
       subject(:titleize) do
         described_class.titleize(


### PR DESCRIPTION
## Purpose
- Support Canadian addresses
- Bind development dependencies to specific gem versions
- Support optional options on `AddressTitlecase::Titleizer` class