### PR TITLE
Support non-ASCII characters, specify minimum Ruby version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  TargetRubyVersion: 2.4
+
 Metrics/LineLength:
   Enabled: false
 

--- a/address_titlecase.gemspec
+++ b/address_titlecase.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.4'
+
   spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'pry-byebug', '~> 3.7'
   spec.add_development_dependency 'rake', '~> 12.3'

--- a/lib/address_titlecase/titleizer.rb
+++ b/lib/address_titlecase/titleizer.rb
@@ -27,7 +27,7 @@ module AddressTitlecase
 
       def titleize(address, opts = {})
         overrides = opts['overrides'] || opts[:overrides] || {}
-        address.gsub(/\w+['’]?\w*/) do |word|
+        address.gsub(/[[:alpha:]]+['’]?[[:alpha:]]*/) do |word|
           overriden_word = overrides[word]
           if overriden_word
             overriden_word

--- a/lib/address_titlecase/version.rb
+++ b/lib/address_titlecase/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AddressTitlecase
-  VERSION = '1.1.1'
+  VERSION = '1.2.1'
 end

--- a/spec/address_titlecase/titleizer_spec.rb
+++ b/spec/address_titlecase/titleizer_spec.rb
@@ -25,9 +25,9 @@ describe AddressTitlecase::Titleizer do
     end
 
     context 'with a Canadian address' do
-      let(:input_address) { "10-123 1/2 MAIN ST SE\nMONTREAL QC H3Z 2Y7" }
+      let(:input_address) { "10-123 1/2 MAIN ST SE\nMONTRÉAL QC H3Z 2Y7" }
 
-      it { is_expected.to eq("10-123 1/2 Main St SE\nMontreal QC H3Z 2Y7") }
+      it { is_expected.to eq("10-123 1/2 Main St SE\nMontréal QC H3Z 2Y7") }
     end
 
     context 'with overrides' do


### PR DESCRIPTION
## Purpose
- Support non-ASCII characters
- Specify Ruby 2.4 as minimum version since capitalization of non-ASCII characters became supported in this version